### PR TITLE
Templatize factories

### DIFF
--- a/Code/Examples/1 - SimpleExample/EntryPoint.cpp
+++ b/Code/Examples/1 - SimpleExample/EntryPoint.cpp
@@ -20,7 +20,7 @@ public:
 
 	void OnCreated() MAX_DOES_NOT_THROW override {
 		// Add controls inside the Form's OnCreated().
-		maxGUI::MultilineTextBoxFactory multiline_textbox_factory(maxGUI::Rectangle(0, 0, 100, 100), "Test");
+		maxGUI::MultilineTextBoxFactory<> multiline_textbox_factory(maxGUI::Rectangle(0, 0, 100, 100), "Multi-line\r\ntest");
 		multiline_textbox_ = AddControl(&multiline_textbox_factory);
 	}
 
@@ -35,23 +35,12 @@ public:
 
 };
 
-// Create a custom form factory that can allocate our custom form.
-class CustomFormFactory : public maxGUI::FormFactory {
-public:
-
-	// TODO: Can we not need to know about HWND somehow?
-	std::unique_ptr<maxGUI::Form> AllocateForm(HWND window_handle) MAX_DOES_NOT_THROW override {
-		return std::make_unique<CustomForm>(window_handle);
-	}
-
-};
-
 // Name your function EXACTLY this, keep it in the global namespace, and make sure it has MAX_DOES_NOT_THROW
 // If you get a linker error of an unresolved external symbol for maxGUIEntryPoint(), you did this wrong.
 int maxGUIEntryPoint(maxGUI::FormContainer&& form_container) MAX_DOES_NOT_THROW {
 	// Create the form
-	CustomFormFactory form_factory;
-	if (!form_container.CreateForm(form_factory)) {
+	maxGUI::FormFactory<CustomForm> custom_form_factory;
+	if (!form_container.CreateForm(custom_form_factory, 400, 600, "Simple Example")) {
 		return -1;
 	}
 	// IMPORTANT: Keep the form factory alive long enough for the form to be created by the message pump

--- a/Code/maxGUI/Button.cpp
+++ b/Code/maxGUI/Button.cpp
@@ -4,8 +4,6 @@
 
 #include <maxGUI/Button.hpp>
 
-#include <utility>
-
 namespace maxGUI
 {
 	
@@ -19,18 +17,11 @@ namespace maxGUI
 			OnPressed();
 		}
 	}
-	
-	ButtonFactory::ButtonFactory(Rectangle rectangle, std::string text) MAX_DOES_NOT_THROW
-		: ControlWithTextFactory(std::move(rectangle), std::move(text))
-	{}
 
-	std::unique_ptr<Control> ButtonFactory::CreateControl(HWND parent_window_handle) const MAX_DOES_NOT_THROW {
+	HWND ButtonFactoryImplementationDetails::CreateButton(std::string text, Rectangle rectangle, HWND parent_window_handle) MAX_DOES_NOT_THROW {
 		// BS_DEFPUSHBUTTON
 		// BS_FLAT
-		HWND window_handle = CreateWindowEx(WS_EX_CLIENTEDGE, TEXT("BUTTON"), TEXT(""), WS_CHILD | WS_VISIBLE | WS_TABSTOP, rectangle_.left_, rectangle_.top_, rectangle_.width_, rectangle_.height_, parent_window_handle, NULL, reinterpret_cast<HINSTANCE>(GetWindowLongPtr(parent_window_handle, GWLP_HINSTANCE)), NULL);
-		// TODO: Convert the std::string (lets go with UTF-8) into TCHAR
-		//SendMessage(window_handle, WM_SETTEXT, 0, static_cast<LPARAM>(tchar_string));
-		return std::make_unique<Button>(std::move(window_handle));
+		return CreateWindowEx(WS_EX_CLIENTEDGE, TEXT("BUTTON"), TEXT(""), WS_CHILD | WS_VISIBLE | WS_TABSTOP, rectangle.left_, rectangle.top_, rectangle.width_, rectangle.height_, parent_window_handle, NULL, reinterpret_cast<HINSTANCE>(GetWindowLongPtr(parent_window_handle, GWLP_HINSTANCE)), NULL);
 	}
 
 } //  namespace maxGUI

--- a/Code/maxGUI/Button.hpp
+++ b/Code/maxGUI/Button.hpp
@@ -9,6 +9,7 @@
 #include <maxGUI/ControlWithText.hpp>
 #include <maxGUI/Rectangle.hpp>
 #include <string>
+#include <utility>
 
 namespace maxGUI
 {
@@ -29,17 +30,32 @@ namespace maxGUI
 
 	};
 	
+	class ButtonFactoryImplementationDetails
+	{
+	public:
+
+		static HWND CreateButton(std::string text, Rectangle rectangle, HWND parent_window_handle) MAX_DOES_NOT_THROW;
+
+	};
+
+	template <typename ButtonType>
 	class ButtonFactory : public ControlWithTextFactory
 	{
 	public:
 
-		ButtonFactory(Rectangle rectangle, std::string text) MAX_DOES_NOT_THROW;
+		ButtonFactory(Rectangle rectangle, std::string text) MAX_DOES_NOT_THROW
+			: ControlWithTextFactory(std::move(rectangle), std::move(text))
+		{}
 
 		~ButtonFactory() MAX_DOES_NOT_THROW override = default;
 
-		std::unique_ptr<Control> CreateControl(HWND parent_window_handle) const MAX_DOES_NOT_THROW override;
+		std::unique_ptr<Control> CreateControl(HWND parent_window_handle) const MAX_DOES_NOT_THROW override {
+			HWND window_handle = ButtonFactoryImplementationDetails::CreateButton(text_, rectangle_, std::move(parent_window_handle));
+			return std::make_unique<ButtonType>(std::move(window_handle));
+		}
 
 	};
+
 
 } //  namespace maxGUI
 

--- a/Code/maxGUI/MultilineTextBox.cpp
+++ b/Code/maxGUI/MultilineTextBox.cpp
@@ -12,16 +12,9 @@ namespace maxGUI
 	MultilineTextBox::MultilineTextBox(HWND window_handle) MAX_DOES_NOT_THROW
 		: ControlWithText(std::move(window_handle))
 	{}
-	
-	MultilineTextBoxFactory::MultilineTextBoxFactory(Rectangle rectangle, std::string text) MAX_DOES_NOT_THROW
-		: ControlWithTextFactory(std::move(rectangle), std::move(text))
-	{}
 
-	std::unique_ptr<Control> MultilineTextBoxFactory::CreateControl(HWND parent_window_handle) const MAX_DOES_NOT_THROW {
-		HWND window_handle = CreateWindowEx(WS_EX_CLIENTEDGE, TEXT("EDIT"), TEXT(""), WS_CHILD | WS_VISIBLE | WS_VSCROLL | WS_HSCROLL | WS_TABSTOP | ES_MULTILINE | ES_WANTRETURN | ES_AUTOVSCROLL | ES_AUTOHSCROLL, rectangle_.left_, rectangle_.top_, rectangle_.width_, rectangle_.height_, parent_window_handle, NULL, reinterpret_cast<HINSTANCE>(GetWindowLongPtr(parent_window_handle, GWLP_HINSTANCE)), NULL);
-		// TODO: Convert the std::string (lets go with UTF-8) into TCHAR
-		//SendMessage(window_handle, WM_SETTEXT, 0, static_cast<LPARAM>(tchar_string));
-		return std::make_unique<MultilineTextBox>(std::move(window_handle));
+	HWND MultilineTextBoxFactoryImplementationDetails::CreateMultilineTextBox(std::string text, Rectangle rectangle, HWND parent_window_handle) MAX_DOES_NOT_THROW {
+		return CreateWindowEx(WS_EX_CLIENTEDGE, TEXT("EDIT"), TEXT(""), WS_CHILD | WS_VISIBLE | WS_VSCROLL | WS_HSCROLL | WS_TABSTOP | ES_MULTILINE | ES_WANTRETURN | ES_AUTOVSCROLL | ES_AUTOHSCROLL, rectangle.left_, rectangle.top_, rectangle.width_, rectangle.height_, parent_window_handle, NULL, reinterpret_cast<HINSTANCE>(GetWindowLongPtr(parent_window_handle, GWLP_HINSTANCE)), NULL);
 	}
 
 } //  namespace maxGUI

--- a/Code/maxGUI/MultilineTextBox.hpp
+++ b/Code/maxGUI/MultilineTextBox.hpp
@@ -23,16 +23,30 @@ namespace maxGUI
 		~MultilineTextBox() MAX_DOES_NOT_THROW override = default;
 
 	};
+
+	class MultilineTextBoxFactoryImplementationDetails
+	{
+	public:
+
+		static HWND CreateMultilineTextBox(std::string text, Rectangle rectangle, HWND parent_window_handle) MAX_DOES_NOT_THROW;
+
+	};
 	
+	template <typename MultilineTextBoxType = MultilineTextBox>
 	class MultilineTextBoxFactory : public ControlWithTextFactory
 	{
 	public:
 
-		MultilineTextBoxFactory(Rectangle rectangle, std::string text) MAX_DOES_NOT_THROW;
+		MultilineTextBoxFactory(Rectangle rectangle, std::string text) MAX_DOES_NOT_THROW
+			: ControlWithTextFactory(std::move(rectangle), std::move(text))
+		{}
 
 		~MultilineTextBoxFactory() MAX_DOES_NOT_THROW override = default;
 
-		std::unique_ptr<Control> CreateControl(HWND parent_window_handle) const MAX_DOES_NOT_THROW override;
+		std::unique_ptr<Control> CreateControl(HWND parent_window_handle) const MAX_DOES_NOT_THROW override {
+			HWND window_handle = MultilineTextBoxFactoryImplementationDetails::CreateMultilineTextBox(text_, rectangle_, parent_window_handle);
+			return std::make_unique<MultilineTextBoxType>(std::move(window_handle));
+		}
 
 	};
 


### PR DESCRIPTION
Right now, users need to create a new derived factory class for
forms/controls any time they want to make a change, including where a
control gets placed on a form. If there are two of the same type of
control on a form, each needs its own factory.

The real goal of the factories is to instantiate a derived form/control.
This same goal can be achieved using templated factories.

This commit templatizes the factories to allow typical code to be easier
to read & write.