### PR TITLE
Update max

### DIFF
--- a/Dependencies/max/Code/max/Compiling/Configuration/Compiler/GCC.hpp
+++ b/Dependencies/max/Code/max/Compiling/Configuration/Compiler/GCC.hpp
@@ -26,7 +26,6 @@
 #if __cplusplus > 201709L
 	MAX_COMPILER_MESSAGE( "Compiling with a newer version of C++ than max recognizes. Using last known version." );
 #elif __cplusplus >= 201709L
-MAX_COMPILER_MESSAGE("test");
 	#define MAX_CPP_20
 #elif __cplusplus >= 201703L
 	#define MAX_CPP_17

--- a/Dependencies/max/Code/max/Compiling/Configuration/Compiler/VC.hpp
+++ b/Dependencies/max/Code/max/Compiling/Configuration/Compiler/VC.hpp
@@ -193,8 +193,10 @@
 
 #if _MSC_FULL_VER >= 190024210 // MSVC++ 14.3 (Visual Studio 2015 Update 3)
 	// Visual Studio 2015 Update 3 introduced the _MSVC_LANG pre-defined macro
-	#if _MSVC_LANG > 201704L
+	#if _MSVC_LANG > 201705L
 		MAX_COMPILER_MESSAGE( "Compiling with a newer version of C++ than max recognizes. Using last known version." );
+	#elif _MSVC_LANG >= 201705L
+		#define MAX_CPP_2A
 	#elif _MSVC_LANG >= 201704L
 		#define MAX_CPP_20
 	#elif _MSVC_LANG >= 201703L


### PR DESCRIPTION
max has been updated to be less noisy when building for MSVC and GCC.
This commit updates max to echo those benefits.