### PR TITLE
Add custom painting example

### DIFF
--- a/Code/Examples/4 - CustomPaintingExample/EntryPoint.cpp
+++ b/Code/Examples/4 - CustomPaintingExample/EntryPoint.cpp
@@ -1,0 +1,110 @@
+// Copyright 2020, The maxGUI Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <maxGUI/EntryPoint.hpp>
+#include <maxGUI/Form.hpp>
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <Windows.h>
+
+#include <memory>
+
+class CustomPaintingForm : public maxGUI::Form {
+public:
+
+	// TODO: Can we not need to know about HWND somehow?
+	explicit CustomPaintingForm(HWND window_handle) noexcept
+		: maxGUI::Form(window_handle)
+	{}
+
+	// An escape hatch is provided so a user is not limited by the library.
+	// A user can implement whatever custom behavior they desire by interacting directly with the underlying API.
+	// Here, we override the window's message handler in Win32 to impelement custom painting.
+	LRESULT OnWindowMessage(UINT message, WPARAM wparam, LPARAM lparam) noexcept override {
+		switch (message) {
+		case WM_ERASEBKGND:
+			return 1; // defer erasing to WM_PAINT
+		case WM_PAINT:
+			{
+				PAINTSTRUCT paint_info;
+				HDC device_context = BeginPaint(window_handle_, &paint_info);
+				
+				int width = paint_info.rcPaint.right - paint_info.rcPaint.left;
+				int height = paint_info.rcPaint.bottom - paint_info.rcPaint.top;
+
+				HBITMAP bitmap_handle = CreateCompatibleBitmap(device_context, width, height);
+				DWORD buffer_size_in_bytes = static_cast<size_t>(width) * height * 4; // 3 color channels, 4th channel is unused
+				auto buffer = std::make_unique<uint8_t[]>(static_cast<size_t>(buffer_size_in_bytes));
+
+
+				// Create a black background with a white circle in it
+				int circle_center_y = 50;
+				int circle_center_x = 75;
+				double radius = 30.0;
+
+				for (int y = paint_info.rcPaint.top; y < paint_info.rcPaint.bottom; y++) {
+					int y_distance = abs(circle_center_y - y);
+
+					for (int x = paint_info.rcPaint.left; x < paint_info.rcPaint.right; x++) {
+						int x_distance = abs(circle_center_x - x);
+
+						double distance_from_pixel_to_circle_center = sqrt(static_cast<double>(x_distance) * x_distance + static_cast<double>(y_distance) * y_distance);
+
+						// Our paint rectangle might not be (0,0) top left.
+						// For example, if the user resizes the window to reveal more, our paint rectangle might only be the newly revealed area.
+						size_t buffer_y_offset = static_cast<size_t>(y) - paint_info.rcPaint.top;
+						size_t buffer_x_offset = static_cast<size_t>(x) - paint_info.rcPaint.left;
+
+						size_t i = ((buffer_y_offset * width) + buffer_x_offset) * 4;
+						if (distance_from_pixel_to_circle_center < radius) {
+							buffer[i+0] = 0xff; // blue channel
+							buffer[i+1] = 0xff; // green channel
+							buffer[i+2] = 0xff; // red channel
+						} else {
+							buffer[i+0] = 0; // blue channel
+							buffer[i+1] = 0; // green channel
+							buffer[i+2] = 0; // red channel
+
+						}
+						buffer[i+3] = 0; // unused channel
+					}
+				}
+
+
+				BITMAPINFO bitmap_info = {0};
+				bitmap_info.bmiHeader.biSize = sizeof(bitmap_info);
+				bitmap_info.bmiHeader.biWidth = width;
+				bitmap_info.bmiHeader.biHeight = -height;
+				bitmap_info.bmiHeader.biPlanes = 1;
+				bitmap_info.bmiHeader.biBitCount = 32;
+				bitmap_info.bmiHeader.biCompression = BI_RGB;
+				bitmap_info.bmiHeader.biSizeImage = buffer_size_in_bytes;
+				HDC memory_dc = CreateCompatibleDC(device_context);
+				SetDIBits(memory_dc, bitmap_handle, 0, height, buffer.get(), &bitmap_info, DIB_RGB_COLORS);
+				HGDIOBJ old_bitmap_handle = SelectObject(memory_dc, bitmap_handle);
+				BitBlt(device_context, paint_info.rcPaint.left, paint_info.rcPaint.top, width, height, memory_dc, 0, 0, SRCCOPY);
+				SelectObject(device_context, old_bitmap_handle);
+				DeleteObject(bitmap_handle);
+				DeleteObject(memory_dc);
+
+				EndPaint(window_handle_, &paint_info);
+			}
+			return 0;
+		}
+
+		// If we didn't specialize the message handling, pass it on to the library's handling.
+		return maxGUI::Form::OnWindowMessage(message, wparam, lparam);
+	}
+
+};
+
+int maxGUIEntryPoint(maxGUI::FormContainer&& form_container) noexcept {
+	maxGUI::FormFactory<CustomPaintingForm> custom_painting_form_factory;
+	if (!form_container.CreateForm(custom_painting_form_factory, 200, 350, "Custom painting")) {
+		return -1;
+	}
+
+	return maxGUI::MessagePump(form_container);
+}

--- a/Projects/VisualStudio/CustomPaintingExample/CustomPaintingExample.vcxproj
+++ b/Projects/VisualStudio/CustomPaintingExample/CustomPaintingExample.vcxproj
@@ -1,0 +1,167 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\Code\Examples\4 - CustomPaintingExample\EntryPoint.cpp" />
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{4da98e98-e98f-4473-85fd-31698746cae2}</ProjectGuid>
+    <RootNamespace>CustomPaintingExample</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v142</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)\$(MSBuildProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)\$(MSBuildProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <IncludePath>$(SolutionDir)\..\..\Code\;$(SolutionDir)\..\..\Dependencies\max\Code\;$(IncludePath)</IncludePath>
+    <LibraryPath>$(SolutionDir)\maxGUI\$(Platform)\$(Configuration)\;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)\$(MSBuildProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)\$(MSBuildProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <IncludePath>$(SolutionDir)\..\..\Code\;$(SolutionDir)\..\..\Dependencies\max\Code\;$(IncludePath)</IncludePath>
+    <LibraryPath>$(SolutionDir)\maxGUI\$(Platform)\$(Configuration)\;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LinkIncremental>true</LinkIncremental>
+    <OutDir>$(SolutionDir)\$(MSBuildProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)\$(MSBuildProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <IncludePath>$(SolutionDir)\..\..\Code\;$(SolutionDir)\..\..\Dependencies\max\Code\;$(IncludePath)</IncludePath>
+    <LibraryPath>$(SolutionDir)\maxGUI\$(Platform)\$(Configuration)\;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LinkIncremental>false</LinkIncremental>
+    <OutDir>$(SolutionDir)\$(MSBuildProjectName)\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)\$(MSBuildProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <IncludePath>$(SolutionDir)\..\..\Code\;$(SolutionDir)\..\..\Dependencies\max\Code\;$(IncludePath)</IncludePath>
+    <LibraryPath>$(SolutionDir)\maxGUI\$(Platform)\$(Configuration)\;$(LibraryPath)</LibraryPath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>maxGUI.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>maxGUI.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>maxGUI.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+    </ClCompile>
+    <Link>
+      <SubSystem>Windows</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>maxGUI.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Projects/VisualStudio/CustomPaintingExample/CustomPaintingExample.vcxproj.filters
+++ b/Projects/VisualStudio/CustomPaintingExample/CustomPaintingExample.vcxproj.filters
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <ClCompile Include="..\..\..\Code\Examples\4 - CustomPaintingExample\EntryPoint.cpp" />
+  </ItemGroup>
+</Project>

--- a/Projects/VisualStudio/maxGUI.sln
+++ b/Projects/VisualStudio/maxGUI.sln
@@ -20,10 +20,20 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ControlGalleryExample", "Co
 		{3A9E3E87-9F00-4240-8E5D-489DC37C73DA} = {3A9E3E87-9F00-4240-8E5D-489DC37C73DA}
 	EndProjectSection
 EndProject
+<<<<<<< HEAD
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "StylingExample", "StylingExample\StylingExample.vcxproj", "{D6501A01-B7E4-4FAD-BE1C-9044216735E0}"
 	ProjectSection(ProjectDependencies) = postProject
 		{3A9E3E87-9F00-4240-8E5D-489DC37C73DA} = {3A9E3E87-9F00-4240-8E5D-489DC37C73DA}
 	EndProjectSection
+=======
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CustomPaintingExample", "CustomPaintingExample\CustomPaintingExample.vcxproj", "{4DA98E98-E98F-4473-85FD-31698746CAE2}"
+<<<<<<< HEAD
+>>>>>>> 212d2a6 (Add custom painting example)
+=======
+	ProjectSection(ProjectDependencies) = postProject
+		{3A9E3E87-9F00-4240-8E5D-489DC37C73DA} = {3A9E3E87-9F00-4240-8E5D-489DC37C73DA}
+	EndProjectSection
+>>>>>>> 93cdab5 (Add custom painting example)
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -65,6 +75,7 @@ Global
 		{5085246A-5C05-4257-8E5C-129E139500EF}.Release|Win32.Build.0 = Release|Win32
 		{5085246A-5C05-4257-8E5C-129E139500EF}.Release|x64.ActiveCfg = Release|x64
 		{5085246A-5C05-4257-8E5C-129E139500EF}.Release|x64.Build.0 = Release|x64
+<<<<<<< HEAD
 		{D6501A01-B7E4-4FAD-BE1C-9044216735E0}.Debug|Win32.ActiveCfg = Debug|Win32
 		{D6501A01-B7E4-4FAD-BE1C-9044216735E0}.Debug|Win32.Build.0 = Debug|Win32
 		{D6501A01-B7E4-4FAD-BE1C-9044216735E0}.Debug|x64.ActiveCfg = Debug|x64
@@ -73,6 +84,16 @@ Global
 		{D6501A01-B7E4-4FAD-BE1C-9044216735E0}.Release|Win32.Build.0 = Release|Win32
 		{D6501A01-B7E4-4FAD-BE1C-9044216735E0}.Release|x64.ActiveCfg = Release|x64
 		{D6501A01-B7E4-4FAD-BE1C-9044216735E0}.Release|x64.Build.0 = Release|x64
+=======
+		{4DA98E98-E98F-4473-85FD-31698746CAE2}.Debug|Win32.ActiveCfg = Debug|Win32
+		{4DA98E98-E98F-4473-85FD-31698746CAE2}.Debug|Win32.Build.0 = Debug|Win32
+		{4DA98E98-E98F-4473-85FD-31698746CAE2}.Debug|x64.ActiveCfg = Debug|x64
+		{4DA98E98-E98F-4473-85FD-31698746CAE2}.Debug|x64.Build.0 = Debug|x64
+		{4DA98E98-E98F-4473-85FD-31698746CAE2}.Release|Win32.ActiveCfg = Release|Win32
+		{4DA98E98-E98F-4473-85FD-31698746CAE2}.Release|Win32.Build.0 = Release|Win32
+		{4DA98E98-E98F-4473-85FD-31698746CAE2}.Release|x64.ActiveCfg = Release|x64
+		{4DA98E98-E98F-4473-85FD-31698746CAE2}.Release|x64.Build.0 = Release|x64
+>>>>>>> 212d2a6 (Add custom painting example)
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Projects/VisualStudio/maxGUI.sln
+++ b/Projects/VisualStudio/maxGUI.sln
@@ -20,20 +20,15 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ControlGalleryExample", "Co
 		{3A9E3E87-9F00-4240-8E5D-489DC37C73DA} = {3A9E3E87-9F00-4240-8E5D-489DC37C73DA}
 	EndProjectSection
 EndProject
-<<<<<<< HEAD
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "StylingExample", "StylingExample\StylingExample.vcxproj", "{D6501A01-B7E4-4FAD-BE1C-9044216735E0}"
 	ProjectSection(ProjectDependencies) = postProject
 		{3A9E3E87-9F00-4240-8E5D-489DC37C73DA} = {3A9E3E87-9F00-4240-8E5D-489DC37C73DA}
 	EndProjectSection
-=======
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "CustomPaintingExample", "CustomPaintingExample\CustomPaintingExample.vcxproj", "{4DA98E98-E98F-4473-85FD-31698746CAE2}"
-<<<<<<< HEAD
->>>>>>> 212d2a6 (Add custom painting example)
-=======
 	ProjectSection(ProjectDependencies) = postProject
 		{3A9E3E87-9F00-4240-8E5D-489DC37C73DA} = {3A9E3E87-9F00-4240-8E5D-489DC37C73DA}
 	EndProjectSection
->>>>>>> 93cdab5 (Add custom painting example)
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -75,7 +70,6 @@ Global
 		{5085246A-5C05-4257-8E5C-129E139500EF}.Release|Win32.Build.0 = Release|Win32
 		{5085246A-5C05-4257-8E5C-129E139500EF}.Release|x64.ActiveCfg = Release|x64
 		{5085246A-5C05-4257-8E5C-129E139500EF}.Release|x64.Build.0 = Release|x64
-<<<<<<< HEAD
 		{D6501A01-B7E4-4FAD-BE1C-9044216735E0}.Debug|Win32.ActiveCfg = Debug|Win32
 		{D6501A01-B7E4-4FAD-BE1C-9044216735E0}.Debug|Win32.Build.0 = Debug|Win32
 		{D6501A01-B7E4-4FAD-BE1C-9044216735E0}.Debug|x64.ActiveCfg = Debug|x64
@@ -84,7 +78,6 @@ Global
 		{D6501A01-B7E4-4FAD-BE1C-9044216735E0}.Release|Win32.Build.0 = Release|Win32
 		{D6501A01-B7E4-4FAD-BE1C-9044216735E0}.Release|x64.ActiveCfg = Release|x64
 		{D6501A01-B7E4-4FAD-BE1C-9044216735E0}.Release|x64.Build.0 = Release|x64
-=======
 		{4DA98E98-E98F-4473-85FD-31698746CAE2}.Debug|Win32.ActiveCfg = Debug|Win32
 		{4DA98E98-E98F-4473-85FD-31698746CAE2}.Debug|Win32.Build.0 = Debug|Win32
 		{4DA98E98-E98F-4473-85FD-31698746CAE2}.Debug|x64.ActiveCfg = Debug|x64
@@ -93,7 +86,6 @@ Global
 		{4DA98E98-E98F-4473-85FD-31698746CAE2}.Release|Win32.Build.0 = Release|Win32
 		{4DA98E98-E98F-4473-85FD-31698746CAE2}.Release|x64.ActiveCfg = Release|x64
 		{4DA98E98-E98F-4473-85FD-31698746CAE2}.Release|x64.Build.0 = Release|x64
->>>>>>> 212d2a6 (Add custom painting example)
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Having an escape hatch is important for users.
Being limited by a library helps noone. An escape hatch allows users to
do what they need and benefit from the library when they can.

This commit adds an example escape hatch usage by doing custom painting.
It is common enough for programs to use their own custom theme rather
than the OS theme. So custom painting makes for a good escape hatch
example.