### PR TITLE
Don't expose HWND to form ctor

### DIFF
--- a/Code/Examples/1 - SimpleExample/EntryPoint.cpp
+++ b/Code/Examples/1 - SimpleExample/EntryPoint.cpp
@@ -9,36 +9,34 @@
 #include <maxGUI/Rectangle.hpp>
 
 // Create a custom form that implements the behavior you want.
-class CustomForm : public maxGUI::Form {
+class CustomForm {
 public:
 
-	// TODO: Can we not need to know about HWND somehow?
-	explicit CustomForm(HWND window_handle) noexcept
-		: maxGUI::Form(window_handle)
-	{}
-
-	void OnCreated() noexcept override {
+	void OnCreated(maxGUI::FormConcept* form) noexcept {
 		// Add controls inside the Form's OnCreated().
 		maxGUI::MultilineTextBoxFactory<> multiline_textbox_factory(maxGUI::Rectangle(0, 0, 100, 100), "Multi-line\r\ntest");
-		multiline_textbox_ = AddControl(&multiline_textbox_factory);
+		multiline_textbox_ = form->AddControl(&multiline_textbox_factory);
 	}
 
-	void OnResized(int new_height, int new_width) noexcept override {
+	void OnResized(maxGUI::FormConcept* /*form*/, int new_height, int new_width) noexcept {
 		// In this example, make the multiline textbox take the entire area.
 		multiline_textbox_->Move(maxGUI::Rectangle(0, 0, new_height, new_width));
 	}
 
-	// The default OnClosed() function will call PostExitMessage(0) to exit the message pump.
+	void OnClosed(maxGUI::FormConcept* /*form*/) noexcept {
+		maxGUI::PostExitMessage(0);
+	}
 
 	maxGUI::Control* multiline_textbox_ = nullptr;
-
 };
 
-// Name your function EXACTLY this, keep it in the global namespace, and make sure it has MAX_DOES_NOT_THROW
+// Name your function EXACTLY this, keep it in the global namespace, and make sure it has noexcept.
 // If you get a linker error of an unresolved external symbol for maxGUIEntryPoint(), you did this wrong.
-int maxGUIEntryPoint(maxGUI::FormContainer&& form_container) noexcept {
+int maxGUIEntryPoint(maxGUI::FormContainer form_container) noexcept {
 	// Create the form
-	maxGUI::FormFactory<CustomForm> custom_form_factory;
+	maxGUI::FormFactory custom_form_factory(maxGUI::GetDefaultFormAllocator<CustomForm>());
+	// TODO: It is weird that the FormContainer has the CreateForm function instead of the FormFactory.
+	// Controls are similar. form.AddControl(factory). Maybe that is okay since it is "add" not "create"?
 	if (!form_container.CreateForm(custom_form_factory, 400, 600, "Simple Example")) {
 		return -1;
 	}

--- a/Code/Examples/2 - StylingExample/EntryPoint.cpp
+++ b/Code/Examples/2 - StylingExample/EntryPoint.cpp
@@ -28,30 +28,29 @@ public:
 
 };
 
-class LoginForm : public maxGUI::Form {
+class LoginForm {
 public:
 
-	// TODO: Can we not need to know about HWND somehow?
-	explicit LoginForm(HWND window_handle) noexcept
-		: maxGUI::Form(window_handle)
-	{}
-
-	void OnCreated() noexcept override {
+	void OnCreated(maxGUI::FormConcept* form) noexcept {
 		maxGUI::LabelFactory<> welcome_label_factory(maxGUI::Rectangle(50, 50, 500, 300), "Login");
-		AddControl(&welcome_label_factory);
+		form->AddControl(&welcome_label_factory);
 
 		maxGUI::TextBoxFactory<> username_textbox_factory(maxGUI::Rectangle(100, 50, 50, 300), "");
-		username_textbox_ = AddControl(&username_textbox_factory);
+		username_textbox_ = form->AddControl(&username_textbox_factory);
 
 		// The extra optional parameter at the end is a bitmask of styles.
 		// Different controls have different optional styles available.
 		// For example, a TextBox can have the Password style which hides the character typed by the user.
 		maxGUI::TextBoxFactory<> password_textbox_factory(maxGUI::Rectangle(150, 50, 50, 300), "", maxGUI::TextBoxStyles::Password);
-		password_textbox_ = AddControl(&password_textbox_factory);
+		password_textbox_ = form->AddControl(&password_textbox_factory);
 
 		// A Button can have the Default style, which allows the user to press Enter at any time to press the button.
 		maxGUI::ButtonFactory<LoginButton> login_button_factory(maxGUI::Rectangle(250, 50, 100, 100), "Login", maxGUI::ButtonStyles::Default);
-		AddControl(&login_button_factory);
+		form->AddControl(&login_button_factory);
+	}
+
+	void OnClosed(maxGUI::FormConcept* /*form*/) noexcept {
+		maxGUI::PostExitMessage(0);
 	}
 
 	maxGUI::Control* username_textbox_ = nullptr;
@@ -59,8 +58,9 @@ public:
 
 };
 
-int maxGUIEntryPoint(maxGUI::FormContainer&& form_container) noexcept {
-	maxGUI::FormFactory<LoginForm> login_form_factory;
+int maxGUIEntryPoint(maxGUI::FormContainer form_container) noexcept {
+	maxGUI::FormFactory login_form_factory(maxGUI::GetDefaultFormAllocator<LoginForm>());
+	// TODO: For controls, the style goes on the factory. Forms shouldn't be different.
 	if (!form_container.CreateForm(login_form_factory, 350, 400, "Login", maxGUI::FormStyles::FixedSize)) {
 		return -1;
 	}

--- a/Code/Examples/3 - ControlGalleryExample/EntryPoint.cpp
+++ b/Code/Examples/3 - ControlGalleryExample/EntryPoint.cpp
@@ -37,57 +37,56 @@ public:
 
 };
 
-class ControlGalleryForm : public maxGUI::Form {
+class ControlGalleryForm {
 public:
 
-	// TODO: Can we not need to know about HWND somehow?
-	explicit ControlGalleryForm(HWND window_handle) noexcept
-		: maxGUI::Form(window_handle)
-	{}
-
-	void OnCreated() noexcept override {
+	void OnCreated(maxGUI::FormConcept* form) noexcept {
 		maxGUI::ButtonFactory<CustomButton> custom_button_factory(maxGUI::Rectangle(25, 25, 50, 150), "Custom Button");
-		AddControl(&custom_button_factory);
+		form->AddControl(&custom_button_factory);
 
 		std::vector<std::string> dropdown_options{"Option 1", "Option 2", "Option 3"};
 		maxGUI::DropDownBoxFactory<> dropdownbox_factory(maxGUI::Rectangle(100, 25, 250, 300), std::move(dropdown_options));
-		AddControl(&dropdownbox_factory);
+		form->AddControl(&dropdownbox_factory);
 
 		// TODO: Add the radio buttons inside the frame
 		maxGUI::FrameFactory<> frame_factory(maxGUI::Rectangle(150, 25, 50, 300), "Frame");
-		AddControl(&frame_factory);
+		form->AddControl(&frame_factory);
 
 		maxGUI::LabelFactory<> label_factory(maxGUI::Rectangle(225, 25, 25, 300), "Label");
-		AddControl(&label_factory);
+		form->AddControl(&label_factory);
 
 		std::vector<std::string> listbox_options{"Item 1", "Item 2", "Item 3"};
 		maxGUI::ListBoxFactory<> listbox_factory(maxGUI::Rectangle(275, 25, 150, 300), std::move(listbox_options));
-		AddControl(&listbox_factory);
+		form->AddControl(&listbox_factory);
 
 		maxGUI::MultilineTextBoxFactory<> multilinetextbox_factory(maxGUI::Rectangle(450, 25, 150, 300), "Multiline\r\ntextbox");
-		AddControl(&multilinetextbox_factory);
+		form->AddControl(&multilinetextbox_factory);
 
 		maxGUI::ProgressBarFactory<> progressbar_factory(maxGUI::Rectangle(625, 25, 25, 300), 0, 100, 50);
-		AddControl(&progressbar_factory);
+		form->AddControl(&progressbar_factory);
 
 		maxGUI::CheckBoxFactory<> checkbox_factory(maxGUI::Rectangle(675, 25, 25, 300), "Check 1");
-		AddControl(&checkbox_factory);
+		form->AddControl(&checkbox_factory);
 
 		// When using multiple RadioButtons that belong to one group, be sure to add the FirstInGroup style to the first option.
 		maxGUI::RadioButtonFactory<> radiobutton_factory(maxGUI::Rectangle(725, 25, 25, 300), "Option 1", maxGUI::RadioButtonStyles::FirstInGroup);
-		AddControl(&radiobutton_factory);
+		form->AddControl(&radiobutton_factory);
 
 		maxGUI::RadioButtonFactory<> radiobutton_factory2(maxGUI::Rectangle(750, 25, 25, 300), "Option 2");
-		AddControl(&radiobutton_factory2);
+		form->AddControl(&radiobutton_factory2);
 
 		maxGUI::TextBoxFactory<> textbox_factory(maxGUI::Rectangle(800, 25, 25, 300), "Textbox");
-		AddControl(&textbox_factory);
+		form->AddControl(&textbox_factory);
+	}
+
+	void OnClosed(maxGUI::FormConcept* /*form*/) noexcept {
+		maxGUI::PostExitMessage(0);
 	}
 
 };
 
-int maxGUIEntryPoint(maxGUI::FormContainer&& form_container) noexcept {
-	maxGUI::FormFactory<ControlGalleryForm> control_gallery_form_factory;
+int maxGUIEntryPoint(maxGUI::FormContainer form_container) noexcept {
+	maxGUI::FormFactory control_gallery_form_factory(maxGUI::GetDefaultFormAllocator<ControlGalleryForm>());
 	if (!form_container.CreateForm(control_gallery_form_factory, 825, 350, "Control gallery", maxGUI::FormStyles::FixedSize)) {
 		return -1;
 	}

--- a/Code/maxGUI/EntryPoint.hpp
+++ b/Code/maxGUI/EntryPoint.hpp
@@ -13,7 +13,7 @@
 
 // The user should implement this function.
 // maxGUI calls this when the program begins.
-int maxGUIEntryPoint(maxGUI::FormContainer&& form_container) noexcept;
+int maxGUIEntryPoint(maxGUI::FormContainer form_container) noexcept;
 
 int
 #if !defined(_MAC)

--- a/Code/maxGUI/Form.cpp
+++ b/Code/maxGUI/Form.cpp
@@ -11,14 +11,15 @@ namespace {
 
 	static LPCTSTR maxgui_window_class_name = TEXT("maxGUI Window Class");
 	static LPCTSTR maxgui_creation_parameters_property_name = TEXT("maxGUI Creation Parameters");
-	static LPCTSTR maxgui_form_property_name = TEXT("maxGUI Form");
+	static LPCTSTR maxgui_formconcept_property_name = TEXT("maxGUI Form");
 
-	maxGUI::Form* GetFormFromHWND(HWND window_handle) {
-		maxGUI::Form* form = nullptr;
 
-		HANDLE property = ::GetProp(window_handle, maxgui_form_property_name);
+	maxGUI::FormConcept* GetFormFromHWND(HWND window_handle) {
+		maxGUI::FormConcept* form = nullptr;
+
+		HANDLE property = ::GetProp(window_handle, maxgui_formconcept_property_name);
 		if (property != NULL) {
-			form = reinterpret_cast<maxGUI::Form*>(property);
+			form = reinterpret_cast<maxGUI::FormConcept*>(property);
 		}
 
 		return form;
@@ -28,83 +29,85 @@ namespace {
 		switch (message)
 		{
 		case WM_NCCREATE:
+		{
+			CREATESTRUCT* creation_parameters = reinterpret_cast<CREATESTRUCT*>(lparam);
+			if (creation_parameters)
 			{
-				CREATESTRUCT* creation_parameters = reinterpret_cast<CREATESTRUCT*>(lparam);
-				if (creation_parameters)
-				{
-					maxGUI::FormFactoryImplementationDetails* form_factory_implementation_details = reinterpret_cast<maxGUI::FormFactoryImplementationDetails*>(creation_parameters->lpCreateParams);
-					BOOL result = SetProp(window_handle, maxgui_creation_parameters_property_name, static_cast<HANDLE>(form_factory_implementation_details));
-					if (result == 0) {
-						return -1;
-					}
+				maxGUI::FormFactory* form_factory = reinterpret_cast<maxGUI::FormFactory*>(creation_parameters->lpCreateParams);
+				BOOL result = SetProp(window_handle, maxgui_creation_parameters_property_name, static_cast<HANDLE>(form_factory));
+				if (result == 0) {
+					return -1;
 				}
 			}
-			return DefWindowProc(window_handle, message, wparam, lparam);
+		}
+		return DefWindowProc(window_handle, message, wparam, lparam);
 		case WM_CREATE:
-			{
-				maxGUI::Form* form = nullptr;
-				HANDLE property = GetProp(window_handle, maxgui_creation_parameters_property_name);
-				if (property != NULL) {
-					maxGUI::FormFactoryImplementationDetails* form_factory_implementation_details = reinterpret_cast<maxGUI::FormFactoryImplementationDetails*>(property);
-					std::unique_ptr<maxGUI::Form> created_form = form_factory_implementation_details->AllocateForm(window_handle);
+		{
+			maxGUI::FormConcept* form = nullptr;
+			HANDLE property = GetProp(window_handle, maxgui_creation_parameters_property_name);
+			if (property != NULL) {
+				maxGUI::FormFactory* form_factory = reinterpret_cast<maxGUI::FormFactory*>(property);
+				std::unique_ptr<maxGUI::FormConcept> created_form = form_factory->form_allocator_->AllocateForm(window_handle);
 
-					RemoveProp(window_handle, maxgui_creation_parameters_property_name);
+				RemoveProp(window_handle, maxgui_creation_parameters_property_name);
 
-					BOOL result = SetProp(window_handle, maxgui_form_property_name, static_cast<HANDLE>(created_form.get()));
-					if (result == 0) {
-						return -1;
-					}
-					form = created_form.get();
-
-					form_factory_implementation_details->form_container_->forms_.push_back(std::move(created_form));
+				BOOL result = SetProp(window_handle, maxgui_formconcept_property_name, static_cast<HANDLE>(created_form.get()));
+				if (result == 0) {
+					return -1;
 				}
-				form->OnCreated();
-			}
-			//return 0;
-			return DefWindowProc(window_handle, message, wparam, lparam);
-		case WM_SIZE:
-			{
-				auto form = GetFormFromHWND(window_handle);
+				form = created_form.get();
 
-				int height = HIWORD(lparam);
-				int width = LOWORD(lparam);
-				form->OnResized(height, width);
+				form_factory->form_container_->forms_.push_back(std::move(created_form));
 			}
-			return TRUE;
+
+			form->OnCreated(form);
+		}
+		//return 0;
+		return DefWindowProc(window_handle, message, wparam, lparam);
+		case WM_SIZE:
+		{
+			auto form = GetFormFromHWND(window_handle);
+
+			int height = HIWORD(lparam);
+			int width = LOWORD(lparam);
+
+			form->OnResized(form, height, width);
+		}
+		return TRUE;
 		// TODO: This should be WM_CLOSE
 		case WM_DESTROY:
-			{
-				auto form = GetFormFromHWND(window_handle);
-				form->OnClosed();
-			}
-			return 0;
+		{
+			auto form = GetFormFromHWND(window_handle);
+			form->OnClosed(form);
+		}
+		return 0;
 		case WM_NCDESTROY:
-			RemoveProp(window_handle, maxgui_form_property_name);
+			RemoveProp(window_handle, maxgui_formconcept_property_name);
 			return 0;
 		case WM_COMMAND:
+		{
+			auto form = GetFormFromHWND(window_handle);
+			if (HIWORD(wparam) == 0 && lparam == 0) // menu
 			{
-				auto form = GetFormFromHWND(window_handle);
-				if (HIWORD(wparam) == 0 && lparam == 0) // menu
-				{
-					//auto menu_identifier = LOWORD(wparam);
-				} else if (HIWORD(wparam) == 1 && lparam == 0) { // accelerator
-					//auto accelerator_identifier = LOWORD(wparam);
-				} else {
-					//auto control_identifier = LOWORD(wparam);
-					HWND control_window_handle = reinterpret_cast<HWND>(lparam);
-					for (auto& control : form->controls_) {
-						if (control->window_handle_ == control_window_handle) {
-							control->OnCommand(HIWORD(wparam));
-						}
+				//auto menu_identifier = LOWORD(wparam);
+			} else if (HIWORD(wparam) == 1 && lparam == 0) { // accelerator
+				//auto accelerator_identifier = LOWORD(wparam);
+			} else {
+				//auto control_identifier = LOWORD(wparam);
+				HWND control_window_handle = reinterpret_cast<HWND>(lparam);
+				for (auto& control : form->controls_) {
+					if (control->window_handle_ == control_window_handle) {
+						control->OnCommand(HIWORD(wparam));
 					}
 				}
 			}
-			return 0;
+		}
+		return 0;
 		}
 
 		auto form = GetFormFromHWND(window_handle);
 		if (form) {
-			return form->OnWindowMessage(message, wparam, lparam);
+			return form->OnWindowMessage(form, message, wparam, lparam);
 		}
 
 		return DefWindowProc(window_handle, message, wparam, lparam);
@@ -114,25 +117,11 @@ namespace {
 
 namespace maxGUI {
 
-	Form::Form(HWND window_handle) noexcept
-		: window_handle_(window_handle)
+	FormConcept::FormConcept(HWND window_handle) noexcept
+		: window_handle_(std::move(window_handle))
 	{}
 
-	void Form::OnCreated() noexcept {
-	}
-
-	void Form::OnResized(int /*new_width*/, int /*new_height*/) noexcept {
-	}
-
-	void Form::OnClosed() noexcept {
-		PostExitMessage(0);
-	}
-
-	LRESULT Form::OnWindowMessage(UINT message, WPARAM wparam, LPARAM lparam) noexcept {
-		return DefWindowProc(window_handle_, message, wparam, lparam);
-	}
-
-	Control* Form::AddControl(const ControlFactory* control_factory) noexcept {
+	Control* FormConcept::AddControl(const ControlFactory* control_factory) noexcept {
 		std::unique_ptr<Control> control_ptr = control_factory->CreateControl(window_handle_);
 		Control* raw_control_ptr = control_ptr.get();
 		controls_.push_back(std::move(control_ptr));
@@ -143,7 +132,11 @@ namespace maxGUI {
 		: instance_handle_(instance_handle)
 	{}
 
-	bool FormFactoryImplementationDetails::CreateForm(HINSTANCE instance_handle, int height, int width, std::string title, FormStyles styles) noexcept {
+	FormFactory::FormFactory(std::unique_ptr<FormAllocatorConcept> form_allocator) noexcept
+		: form_allocator_(std::move(form_allocator))
+	{}
+
+	bool FormFactory::CreateForm(HINSTANCE instance_handle, int height, int width, std::string title, FormStyles styles) noexcept {
 		WNDCLASSEX wcx = {0};
 		wcx.cbSize = sizeof(wcx);
 		wcx.style = 0;

--- a/Code/maxGUI/Form.hpp
+++ b/Code/maxGUI/Form.hpp
@@ -32,19 +32,16 @@ MAX_BITMASKABLE_ENUM_CLASS(maxGUI::FormStyles);
 namespace maxGUI
 {
 
-	class Form {
+	class FormConcept {
 	public:
 
-		explicit Form(HWND window_handle) noexcept;
+		explicit FormConcept(HWND window_handle) noexcept;
+		virtual ~FormConcept() noexcept = default;
 
-		virtual ~Form() noexcept = default;
-
-		virtual void OnCreated() noexcept;
-		virtual void OnResized(int new_height, int new_width) noexcept;
-		virtual void OnClosed() noexcept;
-
-		
-		virtual LRESULT OnWindowMessage(UINT message, WPARAM wparam, LPARAM lparam) noexcept;
+		virtual void OnResized(FormConcept* form, int height, int width) noexcept = 0;
+		virtual void OnClosed(FormConcept* form) noexcept = 0;
+		virtual void OnCreated(FormConcept* form) noexcept = 0;
+		virtual LRESULT OnWindowMessage(FormConcept* form, UINT message, WPARAM wparam, LPARAM lparam) noexcept = 0;
 
 		// TODO: Can this be templated so the factories don't need to be templated?
 		Control* AddControl(const ControlFactory* control_factory) noexcept;
@@ -54,54 +51,76 @@ namespace maxGUI
 
 	};
 
+	template<typename T>
+	class FormModel : public FormConcept {
+	public:
+
+		FormModel(std::unique_ptr<T> form, HWND window_handle) noexcept;
+		~FormModel() noexcept override = default;
+
+		void OnResized(FormConcept* form, int height, int width) noexcept override;
+		void OnClosed(FormConcept* form) noexcept override;
+		void OnCreated(FormConcept* form) noexcept override;
+		LRESULT OnWindowMessage(FormConcept* form, UINT message, WPARAM wparam, LPARAM lparam) noexcept override;
+
+	private:
+
+		std::unique_ptr<T> form_;
+
+	};
+
+	class FormAllocatorConcept {
+	public:
+	
+		virtual ~FormAllocatorConcept() noexcept = default;
+
+		virtual std::unique_ptr<FormConcept> AllocateForm(HWND window_handle) noexcept = 0;
+
+	};
+
+	template<typename T>
+	class FormAllocatorModel : public FormAllocatorConcept {
+	public:
+
+		virtual ~FormAllocatorModel() noexcept override = default;
+		std::unique_ptr<FormConcept> AllocateForm(HWND window_handle) noexcept override;
+
+	};
+
+	template<typename T>
+	std::unique_ptr<FormAllocatorConcept> GetDefaultFormAllocator() noexcept;
+
 	class FormContainer {
 	public:
 
 		explicit FormContainer(HINSTANCE instance_handle) noexcept;
 
 		template <typename FormFactoryType>
-		bool CreateForm(FormFactoryType& form_factory, int height, int width, std::string title) noexcept {
-			return CreateForm(form_factory, std::move(height), std::move(width), std::move(title), FormStyles::None);
-		}
+		bool CreateForm(FormFactoryType& form_factory, int height, int width, std::string title) noexcept;
 
 		template <typename FormFactoryType>
-		bool CreateForm(FormFactoryType& form_factory, int height, int width, std::string title, FormStyles styles) noexcept {
-			form_factory.form_container_ = this;
-			return form_factory.CreateForm(instance_handle_, std::move(height), std::move(width), std::move(title), std::move(styles));
-		}
+		bool CreateForm(FormFactoryType& form_factory, int height, int width, std::string title, FormStyles styles) noexcept;
 
-		std::vector<std::unique_ptr<Form>> forms_;
+		std::vector<std::unique_ptr<FormConcept>> forms_;
 		HINSTANCE instance_handle_;
 
 	};
 
-	class FormFactoryImplementationDetails {
+	class FormFactory {
 	public:
+
+		explicit FormFactory(std::unique_ptr<FormAllocatorConcept> form_allocator) noexcept;
 
 		bool CreateForm(HINSTANCE instance_handle, int height, int width, std::string title, FormStyles styles) noexcept;
 
-		virtual std::unique_ptr<Form> AllocateForm(HWND window_handle) noexcept = 0;
-
 		// This is set by FormContainer::CreateForm() and needs to remain set until WM_CREATE is received
 		FormContainer* form_container_ = nullptr;
-
-	};
-
-	template <typename FormType>
-	class FormFactory : public FormFactoryImplementationDetails {
-	public:
-
-		virtual ~FormFactory() noexcept = default;
-
-		std::unique_ptr<Form> AllocateForm(HWND window_handle) noexcept override {
-			// TODO: Use allocator
-			return std::make_unique<FormType>(window_handle);
-		}
-
-		// TODO: Add allocator
+		std::unique_ptr<FormAllocatorConcept> form_allocator_;
 
 	};
 
 } // namespace maxGUI
+
+#include <maxGUI/Form.inl>
 
 #endif // #ifndef MAXGUI_FORM_HPP

--- a/Code/maxGUI/Form.inl
+++ b/Code/maxGUI/Form.inl
@@ -1,0 +1,127 @@
+// Copyright 2022, The maxGUI Contributors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include <maxGUI/Form.hpp>
+#include <maxGUI/EntryPoint.hpp>
+#include <maxGUI/Win32String.hpp>
+#include <utility>
+
+namespace {
+
+	// TODO: These don't work the way I expect.
+	// Currently, I'm using 'requires' instead. But that's more modern. And I want to support older compilers, too.
+	/*
+	template< typename T >
+	struct HasOnCreated {
+		typedef char yes;
+		struct no { char _[2]; };
+		template< typename U, void(U::*)() = &U::OnCreated>
+		static yes impl(U*);
+		static no impl(...);
+
+		enum { value = sizeof( impl( static_cast<T*>(0) ) ) == sizeof(yes) };
+	};
+
+	template< typename T >
+	struct HasOnResized {
+		typedef char yes;
+		struct no { char _[2]; };
+		template< typename U, void(U::*)() = &U::OnResized>
+		static yes impl(U*);
+		static no impl(...);
+
+		enum { value = sizeof( impl( static_cast<T*>(0) ) ) == sizeof(yes) };
+	};
+
+	template< typename T >
+	struct HasOnClosed {
+		typedef char yes;
+		struct no { char _[2]; };
+		template< typename U, void(U::*)() = &U::OnClosed>
+		static yes impl(U*);
+		static no impl(...);
+
+		enum { value = sizeof( impl( static_cast<T*>(0) ) ) == sizeof(yes) };
+	};
+
+	template< typename T >
+	struct HasOnWindowMessage {
+		typedef char yes;
+		struct no { char _[2]; };
+		template< typename U, void(U::*)() = &U::OnWindowMessage>
+		static yes impl(U*);
+		static no impl(...);
+
+		enum { value = sizeof( impl( static_cast<T*>(0) ) ) == sizeof(yes) };
+	};
+	*/
+
+} // anonymous namespace
+
+namespace maxGUI {
+
+	template<typename T>
+	FormModel<T>::FormModel(std::unique_ptr<T> form, HWND window_handle) noexcept
+		: FormConcept(std::move(window_handle))
+		, form_(std::move(form))
+	{}
+
+	template<typename T>
+	void FormModel<T>::OnResized(FormConcept* form, int height, int width) noexcept {
+		//if (HasOnResized<T>::value) {
+		if constexpr (requires { form_->OnResized(std::move(form), std::move(height), std::move(width)); }) {
+			form_->OnResized(std::move(form), std::move(height), std::move(width));
+		}
+	}
+
+	template<typename T>
+	void FormModel<T>::OnClosed(FormConcept* form) noexcept {
+		//if (HasOnClosed<T>::value) {
+		if constexpr (requires { form_->OnClosed(std::move(form)); }) {
+			form_->OnClosed(std::move(form));
+		}
+	}
+
+	template<typename T>
+	void FormModel<T>::OnCreated(FormConcept* form) noexcept {
+		//if (HasOnCreated<T>::value) {
+		if constexpr (requires { form_->OnCreated(std::move(form)); }) {
+			form_->OnCreated(std::move(form));
+		}
+	}
+
+	template<typename T>
+	LRESULT FormModel<T>::OnWindowMessage(FormConcept* form, UINT message, WPARAM wparam, LPARAM lparam) noexcept {
+		//if (HasOnWindowMessage<T>::value) {
+		if constexpr (requires { form_->OnWindowMessage(std::move(form), std::move(message), std::move(wparam), std::move(lparam)); }) {
+			return form_->OnWindowMessage(std::move(form), std::move(message), std::move(wparam), std::move(lparam));
+		} else {
+			return DefWindowProc(window_handle_, message, wparam, lparam);
+		}
+	}
+
+	template <typename FormFactoryType>
+	bool FormContainer::CreateForm(FormFactoryType& form_factory, int height, int width, std::string title) noexcept {
+		return CreateForm(form_factory, std::move(height), std::move(width), std::move(title), FormStyles::None);
+	}
+
+	template <typename FormFactoryType>
+	bool FormContainer::CreateForm(FormFactoryType& form_factory, int height, int width, std::string title, FormStyles styles) noexcept {
+		form_factory.form_container_ = this;
+		return form_factory.CreateForm(instance_handle_, std::move(height), std::move(width), std::move(title), std::move(styles));
+	}
+
+	template<typename T>
+	std::unique_ptr<FormConcept> FormAllocatorModel<T>::AllocateForm(HWND window_handle) noexcept {
+		auto form = std::make_unique<T>();
+		return std::make_unique<FormModel<T>>(std::move(form), window_handle);
+	}
+
+	template<typename T>
+	std::unique_ptr<FormAllocatorConcept> GetDefaultFormAllocator() noexcept {
+		return std::make_unique<FormAllocatorModel<T>>();
+	}
+
+
+} // namespace maxGUI

--- a/Projects/VisualStudio/ControlGalleryExample/ControlGalleryExample.vcxproj
+++ b/Projects/VisualStudio/ControlGalleryExample/ControlGalleryExample.vcxproj
@@ -32,26 +32,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -107,6 +107,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -122,6 +123,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -137,6 +139,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -152,6 +155,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Projects/VisualStudio/CustomPaintingExample/CustomPaintingExample.vcxproj
+++ b/Projects/VisualStudio/CustomPaintingExample/CustomPaintingExample.vcxproj
@@ -32,26 +32,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -107,6 +107,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -122,6 +123,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -137,6 +139,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -152,6 +155,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Projects/VisualStudio/SimpleExample/SimpleExample.vcxproj
+++ b/Projects/VisualStudio/SimpleExample/SimpleExample.vcxproj
@@ -32,26 +32,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -107,6 +107,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -122,6 +123,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -137,6 +139,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -152,6 +155,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Projects/VisualStudio/StylingExample/StylingExample.vcxproj
+++ b/Projects/VisualStudio/StylingExample/StylingExample.vcxproj
@@ -32,26 +32,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
@@ -107,6 +107,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -122,6 +123,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -137,6 +139,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -152,6 +155,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/Projects/VisualStudio/maxGUI/maxGUI.vcxproj
+++ b/Projects/VisualStudio/maxGUI/maxGUI.vcxproj
@@ -23,6 +23,7 @@
     <None Include="..\..\..\.github\ISSUE_TEMPLATE\feature_request.md" />
     <None Include="..\..\..\.travis.yml" />
     <None Include="..\..\..\AUTHORS" />
+    <None Include="..\..\..\Code\maxGUI\Form.inl" />
     <None Include="..\..\..\Docs\DeprecationSchedule.md" />
     <None Include="..\..\..\Docs\README.md" />
     <None Include="..\..\..\LICENSE" />
@@ -75,32 +76,32 @@
     <ProjectGuid>{3A9E3E87-9F00-4240-8E5D-489DC37C73DA}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>VisualStudio2015</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.17763.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/Projects/VisualStudio/maxGUI/maxGUI.vcxproj.filters
+++ b/Projects/VisualStudio/maxGUI/maxGUI.vcxproj.filters
@@ -48,6 +48,9 @@
     <None Include="..\..\..\Docs\DeprecationSchedule.md">
       <Filter>Docs</Filter>
     </None>
+    <None Include="..\..\..\Code\maxGUI\Form.inl">
+      <Filter>Code</Filter>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Xml Include="..\..\..\Tooling\AppVeyor\junit-results.xml">
@@ -56,9 +59,6 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\..\Code\maxGUI\EntryPoint.cpp">
-      <Filter>Code</Filter>
-    </ClCompile>
-    <ClCompile Include="..\..\..\Code\maxGUI\Form.cpp">
       <Filter>Code</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\Code\maxGUI\Button.cpp">
@@ -110,6 +110,9 @@
       <Filter>Code</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\Code\maxGUI\ControlWithList.cpp">
+      <Filter>Code</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\..\Code\maxGUI\Form.cpp">
       <Filter>Code</Filter>
     </ClCompile>
   </ItemGroup>

--- a/Projects/VisualStudio/maxGUIAutomatedTests/maxGUIAutomatedTests.vcxproj
+++ b/Projects/VisualStudio/maxGUIAutomatedTests/maxGUIAutomatedTests.vcxproj
@@ -32,26 +32,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
There was a TODO to not pass the HWND to the form's ctor.
This exposed a platform-specific piece. To be cross-platform, this would
need to be fixed.

This commit fixes it by no longer relying on an inheritance hierarchy.
Instead, type erasure is used to route messages.

This also means default behavior (like OnClose calling
PostExitMessage(0)) no longer happens for free. As a result, that
default behavior was removed.

There are some knock-on effects of this change like cleaning the
FormAllocator.