### PR TITLE
Improve /Wall handling

### DIFF
--- a/Code/Examples/4 - CustomPaintingExample/EntryPoint.cpp
+++ b/Code/Examples/4 - CustomPaintingExample/EntryPoint.cpp
@@ -68,7 +68,7 @@ public:
 				}
 
 
-				BITMAPINFO bitmap_info = {0};
+				BITMAPINFO bitmap_info = {{0}, {{0}}};
 				bitmap_info.bmiHeader.biSize = sizeof(bitmap_info);
 				bitmap_info.bmiHeader.biWidth = width;
 				bitmap_info.bmiHeader.biHeight = -height;
@@ -77,7 +77,7 @@ public:
 				bitmap_info.bmiHeader.biCompression = BI_RGB;
 				bitmap_info.bmiHeader.biSizeImage = buffer_size_in_bytes;
 				HDC memory_dc = CreateCompatibleDC(device_context);
-				SetDIBits(memory_dc, bitmap_handle, 0, height, buffer.get(), &bitmap_info, DIB_RGB_COLORS);
+				SetDIBits(memory_dc, bitmap_handle, 0, static_cast<UINT>(height), buffer.get(), &bitmap_info, DIB_RGB_COLORS);
 				HGDIOBJ old_bitmap_handle = SelectObject(memory_dc, bitmap_handle);
 				BitBlt(device_context, paint_info.rcPaint.left, paint_info.rcPaint.top, width, height, memory_dc, 0, 0, SRCCOPY);
 				SelectObject(device_context, old_bitmap_handle);

--- a/Code/maxGUI/Button.hpp
+++ b/Code/maxGUI/Button.hpp
@@ -14,7 +14,7 @@
 namespace maxGUI
 {
 
-	enum class ButtonStyles {
+	enum class ButtonStyles : uint8_t {
 		None = 1,
 		Default = 2,
 		Flat = 4,

--- a/Code/maxGUI/CheckBox.cpp
+++ b/Code/maxGUI/CheckBox.cpp
@@ -29,7 +29,7 @@ namespace maxGUI
 	}
 
 	bool CheckBox::IsChecked() const noexcept {
-		return SendMessage(window_handle_, BM_GETCHECK, 0, 0);
+		return SendMessage(window_handle_, BM_GETCHECK, 0, 0) == BST_CHECKED;
 	}
 
 	void CheckBox::Check() noexcept {

--- a/Code/maxGUI/CheckBox.hpp
+++ b/Code/maxGUI/CheckBox.hpp
@@ -14,7 +14,7 @@
 namespace maxGUI
 {
 
-	enum class CheckBoxStyles {
+	enum class CheckBoxStyles : uint8_t {
 		None = 0,
 		Flat = 1,
 	};

--- a/Code/maxGUI/ControlWithText.cpp
+++ b/Code/maxGUI/ControlWithText.cpp
@@ -15,7 +15,7 @@ namespace maxGUI
 	{}
 
 	std::string ControlWithText::GetText() const noexcept {
-		LRESULT length_in_chars = SendMessage(window_handle_, WM_GETTEXTLENGTH, 0, 0);
+		size_t length_in_chars = static_cast<size_t>(SendMessage(window_handle_, WM_GETTEXTLENGTH, 0, 0));
 		TCHAR* buffer = new wchar_t[length_in_chars];
 		SendMessage(window_handle_, WM_GETTEXT, length_in_chars, reinterpret_cast<LPARAM>(buffer));
 		Win32String win32_string(std::move(buffer), std::move(length_in_chars));

--- a/Code/maxGUI/Form.cpp
+++ b/Code/maxGUI/Form.cpp
@@ -178,8 +178,8 @@ namespace maxGUI {
 		DWORD extra_style = WS_EX_CONTROLPARENT | WS_EX_CLIENTEDGE; //WS_EX_WINDOWEDGE;
 
 		AdjustWindowRectEx(&area, win32_styles, FALSE, extra_style);
-		DWORD total_height = 0;
-		DWORD total_width = 0;
+		LONG total_height = 0;
+		LONG total_width = 0;
 		if (virtual_top == CW_USEDEFAULT)
 		{
 			area.bottom -= area.top;

--- a/Code/maxGUI/Form.hpp
+++ b/Code/maxGUI/Form.hpp
@@ -110,6 +110,9 @@ namespace maxGUI
 	public:
 
 		explicit FormFactory(std::unique_ptr<FormAllocatorConcept> form_allocator) noexcept;
+		// Explicitly delete these to silence /Wall on MSVC
+		FormFactory(const FormFactory& rhs) = delete;
+		FormFactory& operator =(const FormFactory& rhs) = delete;
 
 		bool CreateForm(HINSTANCE instance_handle, int height, int width, std::string title, FormStyles styles) noexcept;
 

--- a/Code/maxGUI/ListBox.hpp
+++ b/Code/maxGUI/ListBox.hpp
@@ -15,7 +15,7 @@
 namespace maxGUI
 {
 
-	enum class ListBoxStyles {
+	enum class ListBoxStyles : uint8_t {
 		None = 0,
 		SingleClickMultipleSelection = 1,
 		KeyboardAndClickMultipleSelection = 2,

--- a/Code/maxGUI/ProgressBar.cpp
+++ b/Code/maxGUI/ProgressBar.cpp
@@ -14,7 +14,7 @@ namespace maxGUI
 	{}
 
 	void ProgressBar::SetRange(int min, int max) noexcept {
-		SendMessage(window_handle_, PBM_SETRANGE32, min, max);
+		SendMessage(window_handle_, PBM_SETRANGE32, static_cast<WPARAM>(min), static_cast<LPARAM>(max));
 	}
 
 	void ProgressBar::GetRange(int& min, int& max) noexcept {
@@ -25,7 +25,7 @@ namespace maxGUI
 	}
 
 	void ProgressBar::SetValue(int value) noexcept {
-		SendMessage(window_handle_, PBM_SETPOS, value, 0);
+		SendMessage(window_handle_, PBM_SETPOS, static_cast<WPARAM>(value), 0);
 	}
 
 	int ProgressBar::GetValue() noexcept {
@@ -42,8 +42,8 @@ namespace maxGUI
 		}
 		HWND window_handle = CreateWindowEx(0, PROGRESS_CLASS, TEXT(""), win32_styles, rectangle.left_, rectangle.top_, rectangle.width_, rectangle.height_, parent_window_handle, NULL, reinterpret_cast<HINSTANCE>(GetWindowLongPtr(parent_window_handle, GWLP_HINSTANCE)), NULL);
 
-		SendMessage(window_handle, PBM_SETRANGE32, min, max);
-		SendMessage(window_handle, PBM_SETPOS, value, 0);
+		SendMessage(window_handle, PBM_SETRANGE32, static_cast<WPARAM>(min), static_cast<LPARAM>(max));
+		SendMessage(window_handle, PBM_SETPOS, static_cast<WPARAM>(value), 0);
 		
 		return window_handle;
 	}

--- a/Code/maxGUI/RadioButton.hpp
+++ b/Code/maxGUI/RadioButton.hpp
@@ -14,7 +14,7 @@
 namespace maxGUI
 {
 
-	enum class RadioButtonStyles {
+	enum class RadioButtonStyles : uint8_t {
 		None = 0,
 		FirstInGroup = 1,
 		Flat = 2,

--- a/Code/maxGUI/TextBox.hpp
+++ b/Code/maxGUI/TextBox.hpp
@@ -14,7 +14,7 @@
 namespace maxGUI
 {
 
-	enum class TextBoxStyles {
+	enum class TextBoxStyles : uint8_t {
 		None = 0,
 		Password = 1,
 		ReadOnly = 2,

--- a/Code/maxGUI/Win32String.cpp
+++ b/Code/maxGUI/Win32String.cpp
@@ -39,10 +39,10 @@ namespace maxGUI {
 	Win32String Utf8ToWin32String(std::string text) noexcept {
 		#if defined(UNICODE)
 			int wide_char_count = MultiByteToWideChar(CP_UTF8, 0, text.c_str(), -1, nullptr, 0);
-			wchar_t* wide_string = new wchar_t[wide_char_count];
+			wchar_t* wide_string = new wchar_t[static_cast<size_t>(wide_char_count)];
 			MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, text.c_str(), -1, wide_string, wide_char_count);
 
-			return Win32String(wide_string, wide_char_count);
+			return Win32String(wide_string, static_cast<size_t>(wide_char_count));
 		#else
 			#error "TODO: Implement non-wide version"
 		#endif
@@ -52,7 +52,7 @@ namespace maxGUI {
 		#if defined(UNICODE)
 		// TODO: Make sure we don't overflow the int cast.
 		int utf8_char_count = WideCharToMultiByte(CP_UTF8, 0, text.text_, static_cast<int>(text.char_count_), nullptr, 0, nullptr, nullptr);
-		std::string utf8_string(utf8_char_count, '\0');
+		std::string utf8_string(static_cast<size_t>(utf8_char_count), '\0');
 		// TODO: Make sure we don't overflow the int cast.
 		WideCharToMultiByte(CP_UTF8, 0, text.text_, static_cast<int>(text.char_count_), &utf8_string[0], utf8_char_count, nullptr, nullptr);
 		return utf8_string;

--- a/Projects/VisualStudio/ControlGalleryExample/ControlGalleryExample.vcxproj
+++ b/Projects/VisualStudio/ControlGalleryExample/ControlGalleryExample.vcxproj
@@ -103,7 +103,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
@@ -117,7 +117,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
@@ -135,7 +135,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
@@ -149,7 +149,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>

--- a/Projects/VisualStudio/CustomPaintingExample/CustomPaintingExample.vcxproj
+++ b/Projects/VisualStudio/CustomPaintingExample/CustomPaintingExample.vcxproj
@@ -103,7 +103,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
@@ -117,7 +117,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
@@ -135,7 +135,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
@@ -149,7 +149,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>

--- a/Projects/VisualStudio/SimpleExample/SimpleExample.vcxproj
+++ b/Projects/VisualStudio/SimpleExample/SimpleExample.vcxproj
@@ -103,7 +103,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
@@ -117,7 +117,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
@@ -135,7 +135,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
@@ -149,7 +149,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>

--- a/Projects/VisualStudio/StylingExample/StylingExample.vcxproj
+++ b/Projects/VisualStudio/StylingExample/StylingExample.vcxproj
@@ -103,7 +103,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
@@ -117,7 +117,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
@@ -135,7 +135,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
@@ -149,7 +149,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>


### PR DESCRIPTION
MSVC's /Wall is not great. A lot of standard library & Windows headers
will generate warnings. So it should not be used for regular dev, in my
opinion.

However, it is nice to check in on it from time to time to see if
anything might be unintentionally risky.

This commit addresses all the reasonable issues that /Wall showed.
Some warnings were left as they're basically useless (such as a warning
that padding bytes will be added to the end of a class).