### PR TITLE
Enable modern styles on Windows

### DIFF
--- a/Code/maxGUI/Button.cpp
+++ b/Code/maxGUI/Button.cpp
@@ -29,7 +29,8 @@ namespace maxGUI
 			win32_styles |= BS_FLAT;
 		}
 		Win32String win32_text = Utf8ToWin32String(std::move(text));
-		return CreateWindowEx(WS_EX_CLIENTEDGE, TEXT("BUTTON"), win32_text.text_, win32_styles, rectangle.left_, rectangle.top_, rectangle.width_, rectangle.height_, parent_window_handle, NULL, reinterpret_cast<HINSTANCE>(GetWindowLongPtr(parent_window_handle, GWLP_HINSTANCE)), NULL);
+
+		return CreateWindowEx(0, TEXT("BUTTON"), win32_text.text_, win32_styles, rectangle.left_, rectangle.top_, rectangle.width_, rectangle.height_, parent_window_handle, NULL, reinterpret_cast<HINSTANCE>(GetWindowLongPtr(parent_window_handle, GWLP_HINSTANCE)), NULL);
 	}
 
 } //  namespace maxGUI

--- a/Code/maxGUI/EntryPoint.hpp
+++ b/Code/maxGUI/EntryPoint.hpp
@@ -11,6 +11,12 @@
 #endif
 #include <Windows.h>
 
+// This instructs Microsoft Visual C++ 2005 and later to use ComCtl32.dll version 6.
+// That gives the modern visual styles.
+#pragma comment(linker,"\"/manifestdependency:type='win32' \
+name='Microsoft.Windows.Common-Controls' version='6.0.0.0' \
+processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"")
+
 // The user should implement this function.
 // maxGUI calls this when the program begins.
 int maxGUIEntryPoint(maxGUI::FormContainer form_container) noexcept;


### PR DESCRIPTION
Windows requires special handling to load Common Controls 6. And Common Controls 6 enable the modern styles of XP+.

This commit adds a manifest file to projects linked with maxGUI code. That manifest tells Windows to load Common Controls 6.