### PR TITLE
Fix up to warning level 4 on MSVC

### DIFF
--- a/Code/maxGUI/Button.cpp
+++ b/Code/maxGUI/Button.cpp
@@ -22,12 +22,19 @@ namespace maxGUI
 
 	HWND ButtonFactoryImplementationDetails::CreateButton(std::string text, Rectangle rectangle, ButtonStyles styles, HWND parent_window_handle) noexcept {
 		DWORD win32_styles = WS_CHILD | WS_VISIBLE | WS_TABSTOP;
+		// MSVC at warning level 4 issues C26813 because it wants "if (styles & ButtonStyles::Default) {"
+		// But this doesn't play nicely with enum classes because ultimately it needs to convert to bool.
+		// See https://developercommunity.visualstudio.com/t/C26813-incompatible-with-enum-class/10145182
+		#pragma warning(push)
+		#pragma warning(disable: 26813)
 		if ((styles & ButtonStyles::Default) == ButtonStyles::Default) {
 			win32_styles |= BS_DEFPUSHBUTTON;
 		}
 		if ((styles & ButtonStyles::Flat) == ButtonStyles::Flat) {
 			win32_styles |= BS_FLAT;
 		}
+		#pragma warning(pop)
+
 		Win32String win32_text = Utf8ToWin32String(std::move(text));
 		return CreateWindowEx(WS_EX_CLIENTEDGE, TEXT("BUTTON"), win32_text.text_, win32_styles, rectangle.left_, rectangle.top_, rectangle.width_, rectangle.height_, parent_window_handle, NULL, reinterpret_cast<HINSTANCE>(GetWindowLongPtr(parent_window_handle, GWLP_HINSTANCE)), NULL);
 	}


### PR DESCRIPTION
MSVC warns with C26813 because a bitmask isn't being used in the form "if (my_flag & FLAG_VALUE_1)". But it cannot be used that way because it is an enum class.

This commit disables C26813 only at that location since it is an incorrect warning. A bug has also been filed against MSVC.