### PR TITLE
Fix off-by-one error in GetText()

### DIFF
--- a/Code/maxGUI/ControlWithText.cpp
+++ b/Code/maxGUI/ControlWithText.cpp
@@ -21,10 +21,10 @@ namespace maxGUI
 
 	std::string ControlWithText::GetText() const noexcept {
 #if defined(MAX_PLATFORM_WINDOWS)
-		size_t length_in_chars = static_cast<size_t>(SendMessage(window_handle_, WM_GETTEXTLENGTH, 0, 0));
+		size_t length_in_chars = static_cast<size_t>(SendMessage(window_handle_, WM_GETTEXTLENGTH, 0, 0)) + 1; // +1 for the null
 		TCHAR* buffer = new wchar_t[length_in_chars];
 		SendMessage(window_handle_, WM_GETTEXT, length_in_chars, reinterpret_cast<LPARAM>(buffer));
-		Win32String win32_string(std::move(buffer), std::move(length_in_chars));
+		Win32String win32_string(std::move(buffer), length_in_chars - 1);
 		return Win32StringToUtf8(std::move(win32_string));
 #endif
 #if defined(MAX_PLATFORM_LINUX)


### PR DESCRIPTION
The null terminator is not being accounted for properly in ControlWithText::GetText().

This commit fixes that.