### PR TITLE
Add dark mode support

### DIFF
--- a/Code/maxGUI/EntryPoint.hpp
+++ b/Code/maxGUI/EntryPoint.hpp
@@ -19,6 +19,9 @@
 	#pragma comment(linker,"\"/manifestdependency:type='win32' \
 	name='Microsoft.Windows.Common-Controls' version='6.0.0.0' \
 	processorArchitecture='*' publicKeyToken='6595b64144ccf1df' language='*'\"")
+
+	// TODO: Get function pointers at run-time. Don't import the lib.
+	#pragma comment(lib, "Dwmapi.lib")
 #endif
 
 // The user should implement this function.

--- a/Code/maxGUI/FormContainer.cpp
+++ b/Code/maxGUI/FormContainer.cpp
@@ -117,6 +117,20 @@ namespace maxGUI {
 				}
 			}
 			return 0;
+			case WM_SETTINGCHANGE:
+			{
+				DWORD is_light_mode = {0};
+				DWORD size = sizeof(is_light_mode);
+				auto result = RegGetValueW(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize", L"AppsUseLightTheme", RRF_RT_REG_DWORD, nullptr, &is_light_mode, &size);
+				if (result != ERROR_SUCCESS) {
+					// Not supported
+					return 0;
+				}
+
+				BOOL is_dark_mode = !is_light_mode;
+				DwmSetWindowAttribute(window_handle, DWMWA_USE_IMMERSIVE_DARK_MODE, &is_dark_mode, sizeof(is_dark_mode));
+			}
+			return 0;
 			}
 
 			auto form = GetFormFromHWND(window_handle);

--- a/Code/maxGUI/FormContainer.inl
+++ b/Code/maxGUI/FormContainer.inl
@@ -5,6 +5,8 @@
 #include <maxGUI/FormContainer.hpp>
 
 #if defined(MAX_PLATFORM_WINDOWS)
+	#include <dwmapi.h>
+
 	#include <maxGUI/Win32String.hpp>
 #endif
 
@@ -85,6 +87,14 @@ namespace maxGUI {
 		HWND window_handle = CreateWindowEx(extra_style, /*reinterpret_cast<LPCWSTR>(atom)*/maxgui_window_class_name, win32_title.text_, win32_styles, area.left, area.top, total_width, total_height, 0, 0, instance_handle_, static_cast<LPVOID>(&creation_parameters));
 		if (window_handle == NULL) {
 			return false;
+		}
+
+		DWORD is_light_mode = {0};
+		DWORD size = sizeof(is_light_mode);
+		auto result = RegGetValueW(HKEY_CURRENT_USER, L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize", L"AppsUseLightTheme", RRF_RT_REG_DWORD, nullptr, &is_light_mode, &size);
+		if (result == ERROR_SUCCESS) {
+			BOOL is_dark_mode = !is_light_mode;
+			DwmSetWindowAttribute(window_handle, DWMWA_USE_IMMERSIVE_DARK_MODE, &is_dark_mode, sizeof(is_dark_mode));
 		}
 
 		ShowWindow(window_handle, SW_SHOWNORMAL);


### PR DESCRIPTION
Dark mode support in Win32 is spotty. There is a function to update the title bar. And there is a hidden registry value to check if dark mode is enabled. Also, there is a WM_SETTINGCHANGED sent when the mode is changed.

With these things, a program can support dark mode.

However, the common controls do not have a way of painting in dark mode. They need to be painted manually.

If a user is painting their own controls anyway, perhaps this is fine. And even if not, this is perhaps better than nothing.

This commit adds support for dark mode.