### PR TITLE
Rename the entry point

### DIFF
--- a/Code/maxGUI/maxGUI.hpp
+++ b/Code/maxGUI/maxGUI.hpp
@@ -8,7 +8,7 @@
 #include <maxGUI/Button.hpp>
 #include <maxGUI/CheckBox.hpp>
 #include <maxGUI/DropDownBox.hpp>
-#include <maxGUI/EntryPoint.hpp>
+#include <maxGUI/maxGUIEntryPoint.hpp>
 #include <maxGUI/FormAllocatorConcept.hpp>
 #include <maxGUI/FormAllocatorModel.hpp>
 #include <maxGUI/FormConcept.hpp>

--- a/Code/maxGUI/maxGUIEntryPoint.cpp
+++ b/Code/maxGUI/maxGUIEntryPoint.cpp
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include <maxGUI/EntryPoint.hpp>
+#include <maxGUI/maxGUIEntryPoint.hpp>
 
 #if defined(MAX_PLATFORM_LINUX)
 	#include <QApplication>

--- a/Code/maxGUI/maxGUIEntryPoint.hpp
+++ b/Code/maxGUI/maxGUIEntryPoint.hpp
@@ -2,8 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef MAXGUI_ENTRYPOINT_HPP
-#define MAXGUI_ENTRYPOINT_HPP
+#ifndef MAXGUI_MAXGUIENTRYPOINT_HPP
+#define MAXGUI_MAXGUIENTRYPOINT_HPP
 
 #include <max/Compiling/Configuration.hpp>
 #include <maxGUI/FormContainer.hpp>
@@ -46,4 +46,4 @@ namespace maxGUI {
 
 } // namespace maxGUI
 
-#endif // #ifndef MAXGUI_ENTRYPOINT_HPP
+#endif // #ifndef MAXGUI_MAXGUIENTRYPOINT_HPP

--- a/Projects/Make/Makefile
+++ b/Projects/Make/Makefile
@@ -6,10 +6,10 @@ CXX_SRCS = \
 	../../Code/maxGUI/ControlImplementation.cpp \
 	../../Code/maxGUI/ControlWithText.cpp \
 	../../Code/maxGUI/ControlWithTextImplementation.cpp \
-	../../Code/maxGUI/EntryPoint.cpp \
 	../../Code/maxGUI/FormAllocatorConcept.cpp \
 	../../Code/maxGUI/FormConcept.cpp \
 	../../Code/maxGUI/FormContainer.cpp \
+	../../Code/maxGUI/maxGUIEntryPoint.cpp \
 	../../Code/maxGUI/MultilineTextBoxImplementation.cpp
 	#../../Code/maxGUI/CheckBoxImplementation.cpp \
 	#../../Code/maxGUI/ControlWithList.cpp \

--- a/Projects/VisualStudio/maxGUI/maxGUI.vcxproj
+++ b/Projects/VisualStudio/maxGUI/maxGUI.vcxproj
@@ -57,7 +57,7 @@
     <ClCompile Include="..\..\..\Code\maxGUI\ControlWithText.cpp" />
     <ClCompile Include="..\..\..\Code\maxGUI\ControlWithTextImplementation.cpp" />
     <ClCompile Include="..\..\..\Code\maxGUI\DropDownBoxImplementation.cpp" />
-    <ClCompile Include="..\..\..\Code\maxGUI\EntryPoint.cpp" />
+    <ClCompile Include="..\..\..\Code\maxGUI\maxGUIEntryPoint.cpp" />
     <ClCompile Include="..\..\..\Code\maxGUI\FormAllocatorConcept.cpp" />
     <ClCompile Include="..\..\..\Code\maxGUI\FormConcept.cpp" />
     <ClCompile Include="..\..\..\Code\maxGUI\FormContainer.cpp" />
@@ -82,7 +82,7 @@
     <ClInclude Include="..\..\..\Code\maxGUI\ControlWithTextImplementation.hpp" />
     <ClInclude Include="..\..\..\Code\maxGUI\DropDownBoxImplementation.hpp" />
     <ClInclude Include="..\..\..\Code\maxGUI\DropDownBox.hpp" />
-    <ClInclude Include="..\..\..\Code\maxGUI\EntryPoint.hpp" />
+    <ClInclude Include="..\..\..\Code\maxGUI\maxGUIEntryPoint.hpp" />
     <ClInclude Include="..\..\..\Code\maxGUI\FormAllocatorConcept.hpp" />
     <ClInclude Include="..\..\..\Code\maxGUI\FormAllocatorModel.hpp" />
     <ClInclude Include="..\..\..\Code\maxGUI\FormConcept.hpp" />

--- a/Projects/VisualStudio/maxGUI/maxGUI.vcxproj.filters
+++ b/Projects/VisualStudio/maxGUI/maxGUI.vcxproj.filters
@@ -126,7 +126,7 @@
     </Xml>
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="..\..\..\Code\maxGUI\EntryPoint.cpp">
+    <ClCompile Include="..\..\..\Code\maxGUI\maxGUIEntryPoint.cpp">
       <Filter>Code</Filter>
     </ClCompile>
     <ClCompile Include="..\..\..\Code\maxGUI\Control.cpp">
@@ -194,7 +194,7 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\..\Code\maxGUI\EntryPoint.hpp">
+    <ClInclude Include="..\..\..\Code\maxGUI\maxGUIEntryPoint.hpp">
       <Filter>Code</Filter>
     </ClInclude>
     <ClInclude Include="..\..\..\Code\maxGUI\Button.hpp">


### PR DESCRIPTION
Previously, the entry point file was named EntryPoint.hpp/.cpp. If other projects used that same name, there could be a conflict in intermediate files. In fact, this is pretty much the default.

In order to prevent that conflict, the files are renamed to maxGUIEntryPoint.hpp/.cpp. This is far less likely to cause a conflict.