### PR TITLE
Update MSVC

### DIFF
--- a/Dependencies/max/Code/max/Compiling/Configuration/Compiler/VC.hpp
+++ b/Dependencies/max/Code/max/Compiling/Configuration/Compiler/VC.hpp
@@ -11,8 +11,12 @@
 
 #define MAX_COMPILER_MESSAGE( Message ) __pragma( message( Message ) )
 
-#if _MSC_VER > 1939
-	MAX_COMPILER_MESSAGE( "Compiling with a newer version of MSVC than max recognizes. Using last known version." );
+#if _MSC_VER > 1943
+	MAX_COMPILER_MESSAGE("Compiling with a newer version of MSVC than max recognizes. Using last known version.");
+#elif _MSC_VER >= 1943
+	// MSVC++ (Visual Studio 2022 / version 17.13)
+	#define MAX_COMPILER_VERSION_MAJOR 17
+	#define MAX_COMPILER_VERSION_MINOR 13
 #elif _MSC_VER >= 1939
 	// MSVC++ (Visual Studio 2022 / version 17.9)
 	#define MAX_COMPILER_VERSION_MAJOR 17
@@ -244,8 +248,10 @@
 
 #if _MSC_FULL_VER >= 190024210 // MSVC++ 14.3 (Visual Studio 2015 Update 3)
 	// Visual Studio 2015 Update 3 introduced the _MSVC_LANG pre-defined macro
-	#if _MSVC_LANG > 202004L
-		#MAX_COMPILER_MESSAGE( "Compiling with a newer version of C++ than max recognizes. Using last known version.");
+	#if _MSVC_LANG > 202400L
+		MAX_COMPILER_MESSAGE("Compiling with a newer version of C++ than max recognizes. Using last known version.");
+	#elif _MSVC_LANG >= 202400L
+		#define MAX_CPP_23
 	#elif _MSVC_LANG >= 202004L
 		#define MAX_CPP_20
 	#elif _MSVC_LANG >= 201705L

--- a/Docs/DeprecationSchedule.md
+++ b/Docs/DeprecationSchedule.md
@@ -2,65 +2,58 @@
 
 |Clang version|Release date|max deprecation date|
 |-------------|-----------:|-------------------:|
-|Clang 10.0.x |Mar 24, 2020|             Current|
+|Clang 17.0.x |Sep  9, 2023|             Current|
+|Clang 16.0.x |Mar 18, 2023|        Sep  9, 2028|
+|Clang 15.0.x |Sep  6, 2022|        Mar 18, 2028|
+|Clang 14.0.x |Mar 25, 2022|        Sep  6, 2027|
+|Clang 13.0.x |Oct  4, 2021|        Mar 25, 2027|
+|Clang 12.0.x |Apr 15, 2021|        Oct  4, 2026|
+|Clang 11.0.x |Oct 12, 2020|        Apr 15, 2026|
+|Clang 10.0.x |Mar 24, 2020|        Oct 12, 2025|
 |Clang 9.0.x  |Sep 19, 2019|        Mar 24, 2025|
-|Clang 8.0.x  |Mar 20, 2019|        Sep 19, 2024|
-|Clang 7.0.x  |Sep 19, 2018|        Mar 20, 2024|
-|Clang 6.0.x  |Mar  8, 2018|        Sep 19, 2023|
-|Clang 5.0.x  |Sep  7, 2018|        Mar  8, 2023|
-|Clang 4.0.x  |Mar 13, 2017|        Sep  7, 2023|
-|Clang 3.9.x  |Sep  2, 2016|        Mar 13, 2022|
-|Clang 3.8.x  |Mar  8, 2016|        Sep  2, 2021|
-|Clang 3.7.x  |Sep  1, 2015|        Mar  8, 2021|
-|Clang 3.6.x  |Feb 27, 2015|        Sep  1, 2020|
-|Clang 3.5.x  |Sep  3, 2014|          Deprecated|
+|Clang 8.0.x  |Mar 20, 2019|          Deprecated|
 
 |GCC version|Release date|max deprecation date|
 |-----------|-----------:|-------------------:|
-|GCC 10.1   |May  7, 2020|             Current|
+|GCC 13.2   |Jul 27, 2023|             Current|
+|GCC 13.1   |Apr 26, 2023|        Jul 27, 2028|
+|GCC 12.2   |Aug 19, 2022|        Apr 26, 2028|
+|GCC 12.1   |May  6, 2022|        Aug 19, 2027|
+|GCC 11.3   |Apr 21, 2022|        May  6, 2027|
+|GCC 11.2   |Jul 28, 2021|        Apr 21, 2027|
+|GCC 11.1   |Apr 27, 2021|        Jul 28, 2026|
+|GCC 10.3   |Apr  4, 2021|        Apr 27, 2026|
+|GCC 10.2   |Jul 23, 2020|        Apr  4, 2026|
+|GCC 10.1   |May  7, 2020|        Jul 23, 2025|
 |GCC 9.3    |Mar 12, 2020|        May  7, 2025|
 |GCC 9.2    |Aug 12, 2019|        Mar 12, 2025|
-|GCC 9.1    |May  3, 2019|        Aug 12, 2024|
-|GCC 8.3    |Feb 22, 2019|        May  3, 2024|
-|GCC 8.2    |Jul 26, 2018|        Feb 22, 2024|
-|GCC 7.3    |Jan 25, 2018|        Jul 26, 2023|
-|GCC 7.2    |Aug 14, 2017|        Jan 25, 2023|
-|GCC 7.1    |May  2, 2017|        Aug 14, 2023|
-|GCC 6.3    |Dec 21, 2016|        May  2, 2022|
-|GCC 6.2    |Aug 22, 2016|        Dec 21, 2021|
-|GCC 6.1    |Apr 27, 2016|        Aug 22, 2021|
-|GCC 5.3    |Dec  4, 2015|        Apr 27, 2021|
-|GCC 5.2    |Jul 16, 2015|        Dec  4, 2020|
-|GCC 5.1    |Apr 22, 2015|        Jul 16, 2020|
-|GCC 4.9.x  |Apr 22, 2014|          Deprecated|
+|GCC 9.1    |May  3, 2019|          Deprecated|
 
 |MSVC version      |Release date|max deprecation date|
 |------------------|-----------:|-------------------:|
-|MSVC 16.5.x       |Mar 16, 2020|             Current|
+|MSVC 17.13.x      |Feb 11, 2025|             Current|
+|MSVC 17.9.x       |Feb 13, 2024|        Feb 11, 2030|
+|MSVC 17.8.x       |Nov 14, 2023|        Feb 13, 2029|
+|MSVC 17.7.x       |Aug  8, 2023|        Nov 14, 2028|
+|MSVC 17.6.x       |May 16, 2023|        Aug  8, 2028|
+|MSVC 17.5.x       |Feb 21, 2023|        May 16, 2028|
+|MSVC 17.4.x       |Nov 15, 2022|        Feb 21, 2028|
+|MSVC 17.3.x       |Aug  9, 2022|        Nov 15, 2027|
+|MSVC 17.2.x       |May 10, 2022|        Aug  9, 2027|
+|MSVC 17.1.x       |Feb 15, 2022|        May 10, 2027|
+|MSVC 17.0.x       |Nov  8, 2021|        Feb 15, 2027|
+|MSVC 16.11.x      |Aug 10, 2021|        Nov  8, 2026|
+|MSVC 16.10.x      |May 25, 2021|        Aug 10, 2026|
+|MSVC 16.9.x       |Mar  2, 2021|        May 25, 2026|
+|MSVC 16.8.x       |Nov 10, 2020|        Mar  2, 2026|
+|MSVC 16.7.x       |Aug  5, 2020|        Nov 10, 2025|
+|MSVC 16.6.x       |May 19, 2020|        Aug  5, 2025|
+|MSVC 16.5.x       |Mar 16, 2020|        May 19, 2025|
 |MSVC 16.4.x       |Dec  3, 2019|        Mar 16, 2025|
-|MSVC 16.3.x       |Sep 23, 2019|        Dec  3, 2024|
-|MSVC 16.2.x       |Jul 24, 2019|        Sep 23, 2024|
-|MSVC 16.1.x       |May 21, 2019|        Jul 24, 2024|
-|MSVC 16.0.x       |Apr  2, 2019|        May 21, 2024|
-|MSVC 15.9.x       |Nov 13, 2018|        Apr  2, 2024|
-|MSVC 15.8.x       |Aug 14, 2018|        Nov 13, 2023|
-|MSVC 15.7.x       |May  7, 2018|        Aug 14, 2023|
-|MSVC 15.6.x       |Mar  5, 2018|        May  7, 2023|
-|MSVC 15.5.x       |Dec  4, 2017|        Mar  5, 2023|
-|MSVC 15.4.x       |Oct  9, 2017|        Dec  4, 2022|
-|MSVC 15.3.x       |Aug 14, 2017|        Oct  9, 2022|
-|MSVC 15.2.x       |May 10, 2017|        Aug 14, 2022|
-|MSVC 15.1.x       |Apr  5, 2017|        May 10, 2022|
-|MSVC 15.0.x       |Mar  7, 2017|        Apr  5, 2022|
-|MSVC 2015 Update 3|Jun 27, 2016|        Mar  7, 2022|
-|MSVC 2015 Update 2|Mar 30, 2016|        Jun 27, 2021|
-|MSVC 2015 Update 1|Nov 30, 2015|        Mar 30, 2021|
-|MSVC 2015         |Jul 20, 2015|        Nov 30, 2020|
-|MSVC 2013 Update 4|Nov 12, 2014|        Jul 20, 2020|
-|MSVC 2013 Update 3|Aug  4, 2014|          Deprecated|
+|MSVC 16.3.x       |Sep 23, 2019|          Deprecated|
 
 |Windows version|Release date|max deprecation date|
 |---------------|-----------:|-------------------:|
-|Windows 10     |Jul 29, 2015|             Current|
-|Windows 8.1    |Oct 17, 2013|        Jul 29, 2020|
-|Windows 8      |Oct 26, 2012|          Deprecated|
+|Windows 11     |Oct  5, 2021|             Current|
+|Windows 10     |Jul 29, 2015|        Oct  5, 2026|
+|Windows 8.1    |Oct 17, 2013|          Deprecated|


### PR DESCRIPTION
MSVC 17.13 was released.
This commit updates the deprecation schedule as well as the version of max to understand MSVC 17.13.